### PR TITLE
Add Fluorita theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1,5 +1,11 @@
 [
   {
+  "name": "Fluorita",
+  "repo": "MaverickLewis/Fluorita",
+  "author": "Maverick Lewis",
+  "description": "A crystal-inspired Obsidian theme with deep purple tones, blending elegance, minimalism, and a modern glowing aesthetic."
+  },
+  {
     "name": "Atom",
     "author": "kognise",
     "repo": "kognise/obsidian-atom",


### PR DESCRIPTION
## [Theme] Fluorita ✨

Adding Fluorita theme by Maverick Lewis.  
A crystal-inspired purple theme with deep tones, blending elegance, minimalism, and a modern aesthetic.  

Supports:  
- Dark and Light modes  
- Mobile compatibility  
- Distinctive header styles  
- Fluorite-inspired glow effect  
